### PR TITLE
fix(select): 修改了 select 原有的事件循环模型

### DIFF
--- a/examples/routers/select.vue
+++ b/examples/routers/select.vue
@@ -7,6 +7,7 @@
     </dao-select>
     <br>
     <button class="dao-btn blue" @click="changeSimple">change simple</button>
+    <button class="dao-btn ghost" @click="simple = undefined">set undefined</button>
 
     <br><br>
     <h2>small select</h2>
@@ -145,6 +146,7 @@
         });
       },
       changeSimple() {
+        if (typeof this.simple !== 'number') this.simple = 0;
         if (this.simple === 3) {
           this.type = 0;
         } else if (this.simple === 1) {

--- a/src/components/dao-select/dao-option.vue
+++ b/src/components/dao-select/dao-option.vue
@@ -62,11 +62,6 @@
       label: String,
     },
     beforeCreate() {
-      // 绑定获取 value 事件
-      this.$on('pipe-value', (v) => {
-        this.notActive();
-        if (this.value === v) this.isActive();
-      });
       // 绑定选择事件
       this.$on('status', (val) => {
         this.notActive();
@@ -97,21 +92,18 @@
         this.dispatch('Option-group', 'search-result');
       });
     },
+    mounted() {
+      // 在 option 挂载时将自己的 value 和 slot 中的节点字符串传递给 select
+      this.dispatch('Select', 'init', this.value, this.nodesString);
+    },
     data() {
       return {
         active: false,
         matchedFilter: true,
       };
     },
-    methods: {
-      // 处理点击事件
-      handleClick() {
-        if (this.disabled) return;
-        // 触发 select 中的 on-chosen 事件
-        this.dispatch('Select', 'on-chosen', this.value);
-      },
-      // 触发选择事件
-      changeSelectedText() {
+    computed: {
+      nodesString() {
         // 获取 slot 中的 dom 节点
         const nodes = this.$slots.default;
         let nodesString = '';
@@ -126,12 +118,19 @@
         } else {
           nodesString = this.label;
         }
-        this.dispatch('Select', 'change-display', nodesString);
+        return nodesString;
+      },
+    },
+    methods: {
+      // 处理点击事件
+      handleClick() {
+        if (this.disabled) return;
+        // 触发 select 中的 on-chosen 事件
+        this.dispatch('Select', 'on-chosen', this.value);
       },
       // 当前选中
       isActive() {
         this.active = true;
-        this.changeSelectedText();
       },
       notActive() {
         this.active = false;


### PR DESCRIPTION
## 步骤一

请您按照规范确认这个PR的类型：<!--在相对应类型的 [] 输入 x，此PR能且仅能属于以下种类中的一种。输入x时，请确保[]内只有x字母，没有任何空格字节-->

<!-- 确保源分支基于 develop 分支创建，并向develop 分支提起PR请求（本项目 90% 的PR属于此类型）-->
- [x] feature/docs PR 


## 步骤二

完成以下内容的填写，您就可以顺利提交 Pull Request：

**1. 填写Pull Reqeust主要针对的类型于下一行，选项有：bug/feature(特性)/enhancement(增强)/docs(文档)**
bug

**2. Pull Request的简要介绍（请填于下一行）**
## Select 原有事件模型为：
### 组件初始化时：

1. Select 初始化 

	===(触发 Option 的 pipe-value 事件，传递 v-model value 值)===>

2. Option 接收到 value 与自身 value 值相比对

	===(若不等，修改 active 为 false)===> done

	===(若相等，修改 active 为 true，触发 Select 的 change-display 事件，传递 slot 里的 dom 字符串)===>

3. Select 接收到 dom 字符串，表现在显示内容上

	===(此时会触发组件的 beforeUpdate，触发 Option 的 status 事件，传递 Select 的 value 值)===>

4. Option 接收到 value 值，与自身比对

	===(若不等，修改 active 为 false)===> done

	===(若相等，修改 active 为 true，触发 Select 的 change-display 事件，传递 slot 里的 dom 字符串)===>

5. 最终修改 Select 显示内容

### 组件 v-model 值发生变化时

1. Select v-model 值变化

	===(此时会触发组件的 beforeUpdate，触发 Option 的 status 事件，传递 Select 的 value 值)===>
	
2. Option 接收到 value 值，与自身比对

	===(若不等，修改 active 为 false)===> done

	===(若相等，修改 active 为 true，触发 Select 的 change-display 事件，传递 slot 里的 dom 字符串)===>
	
3. Select 接收到 dom 字符串，表现在显示内容上

> (此处1-3流程会执行两遍，我也不太清楚是为什么)

### 组件 Option 选择

1. 点击 Option 选择选项

	===(触发 Select 的 on-chosen 事件，传递 Option 的 value 值)===>

2. Select 接收到 value 值后将其赋值给 v-model 绑定的 value 值

	===(继续 v-model 值变化的 1-3 流程，此处也是执行两遍)===> done

## 组件修改后的事件模型为：
### 组件初始化时

1. Option 挂载(mounted)到 Dom 中，传递自身的 value 值和显示文本(nodesString)

	===(触发 Select 的 init 事件，将 {value, nodesString} 在不重复的前提下添加到一个数组中保存)===>
	
2. Select 挂载时

	===(触发 Option 的 status 事件，传递 Select 的 value 值)===>
	
3. Option 接收到 value 值与自身比对，相应修改 active 状态，done

### v-model 发生变化

1. watch value 的值，发生变化时

	===(触发 Option 的 status 事件，传递 Select 的 value 值)===>
	
2. Option 接收到 value 值与自身比对，相应修改 active 状态，done

### 组件 Option 选择

1. 点击 Option 选择选项

	===(触发 Select 的 on-chosen 事件，传递 Option 的 value 值)

2. Select 接收到 value 值后将其赋值给 v-model 绑定的 value 值

	===(继续 v-model 发生变化时的 1-2 流程，此处不会重复)===> done

> 由此还修复了 ‘select 当选中选项后，再给 v-model 赋值 null 或者 undefined 无效’ 的 bug
fixes https://github.com/DaoCloud/dao-style-vue/issues/130

**3. Pull Request针对问题的重现方式（没有请在下一行填“无”）**
详见 https://github.com/DaoCloud/dao-style-vue/issues/130 以及 demo

**4. Pull Request可能涉及到的组件范围（没有请在下一行填“无”）**
dao-select

<!-- 如果您是本项目Maintainer的话，请务必在该PR右边的Label栏目中，添加相应的label标签-->
