### PR TITLE
fix(select): 修复 select 当 v-model 值为空对象 {} 时的显示 bug

### DIFF
--- a/examples/routers/select.vue
+++ b/examples/routers/select.vue
@@ -105,7 +105,7 @@
         disabled: undefined,
         tab: undefined,
         loading: undefined,
-        asynchronous: undefined,
+        asynchronous: 2,
         options: [],
         items: [{
           value: 1,

--- a/src/components/dao-select/dao-option.vue
+++ b/src/components/dao-select/dao-option.vue
@@ -94,7 +94,7 @@
     },
     mounted() {
       // 在 option 挂载时将自己的 value 和 slot 中的节点字符串传递给 select
-      this.dispatch('Select', 'init', this.value, this.nodesString);
+      this.dispatch('Select', 'init', this.value, this.nodesString, this.isActive.bind(this));
     },
     destroyed() {
       // 在被销毁时将自己的 value 从 select 的 options 中去除

--- a/src/components/dao-select/dao-select.vue
+++ b/src/components/dao-select/dao-select.vue
@@ -215,7 +215,7 @@
   }
 </style>
 <script>
-  import { find } from 'lodash';
+  import { find, findIndex } from 'lodash';
   import daoDrop from './dropdown.vue';
   import clickoutside from '../../directives/clickoutside';
   import Emitter from '../../mixins/emitter';
@@ -289,17 +289,21 @@
     },
     beforeCreate() {
       // select 初始化，获取所有的 options 的 value 和 节点
-      this.$on('init', (value, nodesString) => {
+      this.$on('init', (value, nodesString, callback) => {
         // 如果已经有这个值则不在添加进去
         if (!find(this.options, { value, nodesString })) {
           this.options.push({ value, nodesString });
         }
+        // 如果这个值和已选值相等则调用回调，将 option 的状态修改一下
+        if (value === this.selectedValue) {
+          callback();
+        }
       });
       // select 选项池更新，删除已被销毁的 option
       this.$on('option-destroy', (value) => {
-        const option = find(this.options, { value });
-        if (option) {
-          this.options.splice(this.options.indexOf(option), 1);
+        const index = findIndex(this.options, { value });
+        if (index > -1) {
+          this.options.splice(index, 1);
         }
       });
       // 绑定一个 on-chosen 事件，定义当 option 点击选择之后需要做的事情


### PR DESCRIPTION
## 步骤一

请您按照规范确认这个PR的类型：<!--在相对应类型的 [] 输入 x，此PR能且仅能属于以下种类中的一种。输入x时，请确保[]内只有x字母，没有任何空格字节-->

<!-- 确保源分支基于 develop 分支创建，并向develop 分支提起PR请求（本项目 90% 的PR属于此类型）-->
- [x] feature/docs/fix PR 


## 步骤二

完成以下内容的填写，您就可以顺利提交 Pull Request：

**1. 填写Pull Reqeust主要针对的类型于下一行，选项有：bug/feature(特性)/enhancement(增强)/docs(文档)**
bug

**2. Pull Request的简要介绍（请填于下一行）**
* 当每个 option 的 value 都是对象形式时，传入 v-model 如果为空对象 {} 时，会显示选中第一项，但是 option 状态中却没有选中，修改了显示判断的方法
* 当 options 动态改变时，已销毁的 option 需要在 select 保存的 options 中删除

详见 demo

**3. Pull Request针对问题的重现方式（没有请在下一行填“无”）**


**4. Pull Request可能涉及到的组件范围（没有请在下一行填“无”）**
dao-select

<!-- 如果您是本项目Maintainer的话，请务必在该PR右边的Label栏目中，添加相应的label标签-->
