### PR TITLE
fix(copy-block): 修复 copy-block 动态修改了内容之后复制内容出错的 bug

### DIFF
--- a/examples/routers/clipboard.vue
+++ b/examples/routers/clipboard.vue
@@ -40,7 +40,8 @@
       <br>
       <h2> Copy Block with button </h2>
       <br>
-      <dao-copy-block>asjdahkdjagsdjahgsdjgajsgdagjs</dao-copy-block>
+      <dao-copy-block>asjdahkdjagsdjah {{ text }} gsdjgajsgdagjs</dao-copy-block>
+      <button class="dao-btn ghost" @click="text = `${Math.random()}`">change</button>
     </div>
   </div>
 </template>
@@ -48,12 +49,17 @@
 <script>
   export default {
     name: 'ClipboardRouter',
+    data() {
+      return {
+        text: 'mimo',
+      };
+    },
     methods: {
-      greeting: function() {
+      greeting() {
         alert('content copied');
-      }
-    }
-  }
+      },
+    },
+  };
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/dao-clipboard/dao-copy-block.vue
+++ b/src/components/dao-clipboard/dao-copy-block.vue
@@ -33,14 +33,19 @@
         default: true,
       },
     },
-    computed: {
-      content() {
-        return this.$slots.default[0].text;
-      },
+    // 原本简单的用 computed 无法及时的获取到已修改的内容
+    // 改成当组件挂载和更新之后赋值，可以及时获取
+    // 暂时没有想到更好的解决办法，留待改进
+    mounted() {
+      this.content = this.$slots.default[0].text;
+    },
+    updated() {
+      this.content = this.$slots.default[0].text;
     },
     data() {
       return {
         copied: false,
+        content: '',
       };
     },
     methods: {


### PR DESCRIPTION
## 步骤一

请您按照规范确认这个PR的类型：<!--在相对应类型的 [] 输入 x，此PR能且仅能属于以下种类中的一种。输入x时，请确保[]内只有x字母，没有任何空格字节-->

<!-- 确保源分支基于 develop 分支创建，并向develop 分支提起PR请求（本项目 90% 的PR属于此类型）-->
- [x] feature/fix/docs PR 

## 步骤二

完成以下内容的填写，您就可以顺利提交 Pull Request：

**1. 填写Pull Reqeust主要针对的类型于下一行，选项有：bug/feature(特性)/enhancement(增强)/docs(文档)**
bug

**2. Pull Request的简要介绍（请填于下一行）**
当使用 copy-block 时，内容如果涉及到动态修改，点击 copy 按钮无法复制到修改后的内容，而是修改之前的内容，原因是 computed 属性无法动态的获取 $slots 中的动态改变

已修复此 bug，详见 demo

**3. Pull Request针对问题的重现方式（没有请在下一行填“无”）**


**4. Pull Request可能涉及到的组件范围（没有请在下一行填“无”）**
dao-copy-block

<!-- 如果您是本项目Maintainer的话，请务必在该PR右边的Label栏目中，添加相应的label标签-->
