### PR TITLE
fix(dao-table): 修复 dao-table 在 firefox 28 中无法正常显示的 bug

### DIFF
--- a/src/components/dao-table/dao-table.scss
+++ b/src/components/dao-table/dao-table.scss
@@ -156,6 +156,7 @@
   margin-left: 0;
   margin-right: 0;
   thead {
+    display: flex;
     tr {
       height: $row-th-height;
     }
@@ -169,7 +170,13 @@
       margin-right: $svg-margin-right;
     }
   }
+  tbody {
+    display: flex;
+    flex-direction: column;
+  }
   tr {
+    display: flex;
+    flex: 1;
     border-color: $border-outer-color;
   }
   td {
@@ -208,7 +215,11 @@
 
 .dao-table.slat, .dao-table-slat {
   thead {
+    display: flex;
     tr {
+
+      display: flex;
+      flex: 1;
       height: $row-th-height;
     }
   }


### PR DESCRIPTION
## 步骤一

请您按照规范确认这个PR的类型：<!--在相对应类型的 [] 输入 x，此PR能且仅能属于以下种类中的一种。输入x时，请确保[]内只有x字母，没有任何空格字节-->

<!-- 确保源分支基于 develop 分支创建，并向develop 分支提起PR请求（本项目 90% 的PR属于此类型）-->
- [x] feature/fix/docs PR 
<!-- 确保源分支基于 master 分支创建，并向 master 分支提PR，以及向develop分支提PR（只有绝少数PR属于此类型）-->
- [ ] hotfix PR 
<!-- 确保源分支基于 develop 分支创建，并向 master 分支提PR，以及向develop分支提PR（只有绝少数PR属于此类型）-->
- [ ] release PR

## 步骤二

完成以下内容的填写，您就可以顺利提交 Pull Request：

**1. 填写Pull Reqeust主要针对的类型于下一行，选项有：bug/feature(特性)/enhancement(增强)/docs(文档)**


**2. Pull Request的简要介绍（请填于下一行）**
主要修复 dao-table-flexrow 和 dao-table-slat 的 thead 在 firefox 28 中无法正常显示的 bug

**3. Pull Request针对问题的重现方式（没有请在下一行填“无”）**
构建好，放到 DCE 中看应用列表和负载均衡列表，如果没问题就 ok

**4. Pull Request可能涉及到的组件范围（没有请在下一行填“无”）**


<!-- 如果您是本项目Maintainer的话，请务必在该PR右边的Label栏目中，添加相应的label标签-->
