### PR TITLE
fix(setting-layout): 修复在 firefox28 下，块内容标题的分割线左右渐变颜色不对的问题

### DIFF
--- a/src/components/dao-setting-layout/dao-setting-layout.scss
+++ b/src/components/dao-setting-layout/dao-setting-layout.scss
@@ -78,7 +78,7 @@ $border-radius-size: 4px;
         width: 100%;
         margin: 10px 0 0;
         border: none;
-        background: linear-gradient(to right, transparent 0, $border-color 30px, $border-color calc(100% - 30px), transparent 100%);
+        background: linear-gradient(to right, $background-color-title 0, $border-color 30px, $border-color calc(100% - 30px), $background-color-title 100%);
         height: 1px;
         // 不要使用 transform 去移动，在chrome30 下会失效
         left: 0px;


### PR DESCRIPTION
## 步骤一

请您按照规范确认这个PR的类型：<!--在相对应类型的 [] 输入 x，此PR能且仅能属于以下种类中的一种。输入x时，请确保[]内只有x字母，没有任何空格字节-->

<!-- 确保源分支基于 develop 分支创建，并向develop 分支提起PR请求（本项目 90% 的PR属于此类型）-->
- [x] feature/fix/docs PR 
<!-- 确保源分支基于 master 分支创建，并向 master 分支提PR，以及向develop分支提PR（只有绝少数PR属于此类型）-->
- [ ] hotfix PR 
<!-- 确保源分支基于 develop 分支创建，并向 master 分支提PR，以及向develop分支提PR（只有绝少数PR属于此类型）-->
- [ ] release PR

## 步骤二

完成以下内容的填写，您就可以顺利提交 Pull Request：

**1. 填写Pull Reqeust主要针对的类型于下一行，选项有：bug/feature(特性)/enhancement(增强)/docs(文档)**
bug

**2. Pull Request的简要介绍（请填于下一行）**
修复在 firefox28 下，块内容标题的分割线左右渐变颜色不对的问题

**3. Pull Request针对问题的重现方式（没有请在下一行填“无”）**
![image](https://user-images.githubusercontent.com/19180212/35086595-03a5162a-fc68-11e7-8c26-f2cfadabe437.png)


**4. Pull Request可能涉及到的组件范围（没有请在下一行填“无”）**
setting-layout

<!-- 如果您是本项目Maintainer的话，请务必在该PR右边的Label栏目中，添加相应的label标签-->
