### PR TITLE
update: Dockerfile 分层，安装 npm 包时尽量使用到 cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM node:8.12-alpine as builder
 
 WORKDIR /app
+COPY package.json /app/package.json
+RUN npm install --only=prod
+
 COPY . /app
-RUN npm install --only=prod \
-    && npm run docs
+RUN npm run docs
 
 FROM nginx:alpine
 


### PR DESCRIPTION
更新 Dockerfile 构建时候的分层
  - 原先将整个 context 添加到 /app 后再 npm install，context 有哈希变动就会重新下载 npm 包
  - 现在先添加 package.json 到 /app，npm install 完了再把 context 中内容拷贝进来，这样只要 package.json 哈希没变，就会使用这一层的 cache