### PR TITLE
fix(input):修复 float 类型数字输入框，快速输入时不能输入. 的问题

### DIFF
--- a/src/components/dao-input/dao-numeric-input.vue
+++ b/src/components/dao-input/dao-numeric-input.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="wrapClass">
-    <input :class="inputClass" type="text" 
-      :placeholder="placeholder" 
+    <input :class="inputClass" type="text"
+      :placeholder="placeholder"
       :disabled="disabled"
       @input="onInput"
       @keydown="onKeyDown"
@@ -159,6 +159,7 @@
               return;
             }
             this.updateModel();
+            return;
           }
         }
         this.reset();


### PR DESCRIPTION
**1. PR 内容和 Issue 链接**
- 修复 dao-numeric-input 为 float 类型。__快速__ 输入末尾为` .` 的数字，无法输入。
- http://jira.daocloud.io/browse/DCE-11583

**2. PR 针对问题的重现方式**
-  __快速__ 输入末尾为` .` 的数字

**3. PR 涉及到的组件**
- dao-numeric-input 

**4. 其它您认为有价值的信息**
